### PR TITLE
Initial revision of FavoritesManager

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -20,7 +20,7 @@ end
 target 'SubwayMapTests' do
     import_pods
     
-    pod 'Quick', '~> 0.3.1'
-    pod 'Nimble', '~> 1.0.0'
+    pod 'Quick'
+    pod 'Nimble'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -19,5 +19,8 @@ end
 
 target 'SubwayMapTests' do
     import_pods
+    
+    pod 'Quick', '~> 0.3.1'
+    pod 'Nimble', '~> 1.0.0'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Crashlytics (3.6.0):
+  - Crashlytics (3.7.0):
     - Fabric (~> 1.6.3)
-  - Fabric (1.6.4)
+  - Fabric (1.6.7)
   - GTFSStations (0.0.2):
     - SQLite.swift
   - NagController (0.0.1)
-  - Nimble (1.0.0)
-  - Quick (0.3.1)
+  - Nimble (4.0.0)
+  - Quick (0.9.1)
   - SBCategories (0.1.1)
   - SBTextInputView (0.2.0)
-  - SQLite.swift (0.9.2)
+  - SQLite.swift (0.10.1)
   - ZipArchive (1.4.0)
 
 DEPENDENCIES:
@@ -17,8 +17,8 @@ DEPENDENCIES:
   - Fabric
   - GTFSStations (from `https://github.com/schrockblock/gtfs-stations`, branch `develop`)
   - NagController (from `https://github.com/schrockblock/nag-controller`)
-  - Nimble (~> 1.0.0)
-  - Quick (~> 0.3.1)
+  - Nimble
+  - Quick
   - SBCategories
   - SBTextInputView (from `https://github.com/schrockblock/SBTextInputView`)
   - SQLite.swift (from `https://github.com/stephencelis/SQLite.swift.git`)
@@ -46,21 +46,21 @@ CHECKOUT OPTIONS:
     :commit: 82bffa968c0c915ef16f49c8383e581a190ba042
     :git: https://github.com/schrockblock/SBTextInputView
   SQLite.swift:
-    :commit: d304343f5e9243d17197365d4ce8249e9b7ce84e
+    :commit: ccf43925aacf9fcc6130639247b3e7578a1c727a
     :git: https://github.com/stephencelis/SQLite.swift.git
 
 SPEC CHECKSUMS:
-  Crashlytics: e4e8d02914f2608fbc7bf42b1a7af838b0db67a2
-  Fabric: ed41fd62173c6bdea24ab02c9d7707161eabb750
+  Crashlytics: c3a2333dea9e2733d2777f730910321fc9e25c0d
+  Fabric: caf7580c725e64db144f610ac65cd60956911dc7
   GTFSStations: 6493dce849b1356d6168fc48172bd98eb892439c
   NagController: ea7b0c2565bd92b2312594216a784f642041ef55
-  Nimble: 8bee528e5fcc403653076545db562d2b5db7bb87
-  Quick: 824572d3d198d51e52cf4aa722cebf7e59952a35
+  Nimble: 72bcc3e2f02242e6bfaaf8d9412ca7bfe3d8b417
+  Quick: a5221fc21788b6aeda934805e68b061839bc3165
   SBCategories: a2a126ee06eeacaac02d5e68533cd9de1b9bf1cc
   SBTextInputView: 7446058ca286fb7e195bcb1fab89fc0587cb38cd
-  SQLite.swift: 5dca22dbf6634fdb9c3270fae9491830804e9b2d
+  SQLite.swift: 6a6e4b034efc317ce4e203b6af2d3024fee2b570
   ZipArchive: e25a4373192673e3229ac8d6e9f64a3e5713c966
 
-PODFILE CHECKSUM: eb8ccc8a7dadd5cf00a3e88f025b89a5cdebd3cf
+PODFILE CHECKSUM: 4aa83c83fd9f234f32a4477d7e2a0ac4fcc863e6
 
-COCOAPODS: 1.0.0.beta.2
+COCOAPODS: 1.0.0.beta.5

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,6 +5,8 @@ PODS:
   - GTFSStations (0.0.2):
     - SQLite.swift
   - NagController (0.0.1)
+  - Nimble (1.0.0)
+  - Quick (0.3.1)
   - SBCategories (0.1.1)
   - SBTextInputView (0.2.0)
   - SQLite.swift (0.9.2)
@@ -15,6 +17,8 @@ DEPENDENCIES:
   - Fabric
   - GTFSStations (from `https://github.com/schrockblock/gtfs-stations`, branch `develop`)
   - NagController (from `https://github.com/schrockblock/nag-controller`)
+  - Nimble (~> 1.0.0)
+  - Quick (~> 0.3.1)
   - SBCategories
   - SBTextInputView (from `https://github.com/schrockblock/SBTextInputView`)
   - SQLite.swift (from `https://github.com/stephencelis/SQLite.swift.git`)
@@ -50,6 +54,8 @@ SPEC CHECKSUMS:
   Fabric: ed41fd62173c6bdea24ab02c9d7707161eabb750
   GTFSStations: 6493dce849b1356d6168fc48172bd98eb892439c
   NagController: ea7b0c2565bd92b2312594216a784f642041ef55
+  Nimble: 8bee528e5fcc403653076545db562d2b5db7bb87
+  Quick: 824572d3d198d51e52cf4aa722cebf7e59952a35
   SBCategories: a2a126ee06eeacaac02d5e68533cd9de1b9bf1cc
   SBTextInputView: 7446058ca286fb7e195bcb1fab89fc0587cb38cd
   SQLite.swift: 5dca22dbf6634fdb9c3270fae9491830804e9b2d

--- a/SubwayMap.xcodeproj/project.pbxproj
+++ b/SubwayMap.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		49F531DE1B6E9E5B00A9E887 /* DatabaseLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F531DC1B6E9E5B00A9E887 /* DatabaseLoader.swift */; };
 		59A4CE88EB7ED1203DE138D4 /* Pods_SubwayMapTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A868E11E4A809C123EF6F4E9 /* Pods_SubwayMapTests.framework */; };
 		DF4B99A0190F44320C591BFA /* Pods_SubwayMap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1AD6E17ADA74144E92FD327 /* Pods_SubwayMap.framework */; };
+		8355AC6C1B94A1B2002F0527 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8355AC6B1B94A1B2002F0527 /* FavoritesManager.swift */; };
+		8355AC6D1B94A1B2002F0527 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8355AC6B1B94A1B2002F0527 /* FavoritesManager.swift */; };
+		8355AC6F1B94A1C8002F0527 /* FavoritesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8355AC6E1B94A1C8002F0527 /* FavoritesManagerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +62,9 @@
 
 /* Begin PBXFileReference section */
 		04DFCE702E06D194260037D2 /* Pods-SubwayMapTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMapTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests.debug.xcconfig"; sourceTree = "<group>"; };
+		2FEF38240487DE01F31F28D9 /* Pods_SubwayMapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		36DF562699FA113857BB7C43 /* Pods-SubwayMapTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMapTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests.release.xcconfig"; sourceTree = "<group>"; };
+		387A1DFA8D56DD71BF31F3C5 /* Pods_SubwayMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4918311C1B672B6900EB8328 /* SubwayMap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SubwayMap.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		491831201B672B6900EB8328 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		491831211B672B6900EB8328 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -85,11 +91,13 @@
 		49F531D61B6D4DD500A9E887 /* NYCRouteColorManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYCRouteColorManager.swift; sourceTree = "<group>"; };
 		49F531D91B6D591C00A9E887 /* PredictionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictionViewModel.swift; sourceTree = "<group>"; };
 		49F531DC1B6E9E5B00A9E887 /* DatabaseLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseLoader.swift; sourceTree = "<group>"; };
+<<<<<<< fde24404982395d1d7495df53085632bda315c42
 		4BB8308FBA1DFDFC7E5081B5 /* Pods-SubwayMap.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMap.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap.debug.xcconfig"; sourceTree = "<group>"; };
 		A13F3E14FA8E73B74979798F /* Pods-SubwayMap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMap.release.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap.release.xcconfig"; sourceTree = "<group>"; };
 		A868E11E4A809C123EF6F4E9 /* Pods_SubwayMapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABF52ACD35DF59C8247AC37A /* Pods-SubwayMapTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMapTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests.release.xcconfig"; sourceTree = "<group>"; };
-		F1AD6E17ADA74144E92FD327 /* Pods_SubwayMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1AD6E17ADA74144E92FD327 /* Pods_SubwayMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };		8355AC6B1B94A1B2002F0527 /* FavoritesManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesManager.swift; sourceTree = "<group>"; };
+		8355AC6E1B94A1C8002F0527 /* FavoritesManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesManagerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,6 +181,7 @@
 		491831341B672B6900EB8328 /* SubwayMapTests */ = {
 			isa = PBXGroup;
 			children = (
+				8355AC6E1B94A1C8002F0527 /* FavoritesManagerTests.swift */,
 				491831371B672B6900EB8328 /* SubwayMapTests.swift */,
 				491831351B672B6900EB8328 /* Supporting Files */,
 			);
@@ -222,6 +231,7 @@
 		49F531D21B6D4C2300A9E887 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				8355AC6B1B94A1B2002F0527 /* FavoritesManager.swift */,
 				49F531D61B6D4DD500A9E887 /* NYCRouteColorManager.swift */,
 				49F531D91B6D591C00A9E887 /* PredictionViewModel.swift */,
 				49F531DC1B6E9E5B00A9E887 /* DatabaseLoader.swift */,
@@ -476,6 +486,7 @@
 				49D5359E1B69C44C0087D368 /* MapViewController.swift in Sources */,
 				499EC99A1BEABE7F004A1553 /* LineViewModel.swift in Sources */,
 				49F531D71B6D4DD500A9E887 /* NYCRouteColorManager.swift in Sources */,
+				8355AC6C1B94A1B2002F0527 /* FavoritesManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -489,10 +500,12 @@
 				499EC9971BEAA6F8004A1553 /* LineChoiceView.swift in Sources */,
 				49F531DE1B6E9E5B00A9E887 /* DatabaseLoader.swift in Sources */,
 				491831441B672E8C00EB8328 /* StationViewController.swift in Sources */,
+				8355AC6F1B94A1C8002F0527 /* FavoritesManagerTests.swift in Sources */,
 				491831D31B69A61700EB8328 /* PredictionTableViewCell.swift in Sources */,
 				49D5359F1B69C44C0087D368 /* MapViewController.swift in Sources */,
 				499EC99B1BEABE7F004A1553 /* LineViewModel.swift in Sources */,
 				49F531D81B6D4DD500A9E887 /* NYCRouteColorManager.swift in Sources */,
+				8355AC6D1B94A1B2002F0527 /* FavoritesManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SubwayMap.xcodeproj/project.pbxproj
+++ b/SubwayMap.xcodeproj/project.pbxproj
@@ -29,6 +29,10 @@
 		499EC9981BEAA701004A1553 /* LineChoiceView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 499EC9951BEA947C004A1553 /* LineChoiceView.xib */; };
 		499EC99A1BEABE7F004A1553 /* LineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499EC9991BEABE7F004A1553 /* LineViewModel.swift */; };
 		499EC99B1BEABE7F004A1553 /* LineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499EC9991BEABE7F004A1553 /* LineViewModel.swift */; };
+		49B5C8BB1BE1AB8D00636717 /* FavoritesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B5C8B91BE1AB8D00636717 /* FavoritesViewController.swift */; };
+		49B5C8BC1BE1AB8D00636717 /* FavoritesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B5C8B91BE1AB8D00636717 /* FavoritesViewController.swift */; };
+		49B5C8BD1BE1AB8D00636717 /* FavoritesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49B5C8BA1BE1AB8D00636717 /* FavoritesViewController.xib */; };
+		49B5C8BE1BE1AB8D00636717 /* FavoritesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49B5C8BA1BE1AB8D00636717 /* FavoritesViewController.xib */; };
 		49B5C8C71BE247C200636717 /* StationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B5C8C51BE247C200636717 /* StationTableViewCell.swift */; };
 		49B5C8C81BE247C200636717 /* StationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B5C8C51BE247C200636717 /* StationTableViewCell.swift */; };
 		49B5C8C91BE247C200636717 /* StationTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49B5C8C61BE247C200636717 /* StationTableViewCell.xib */; };
@@ -43,11 +47,11 @@
 		49F531DB1B6D591C00A9E887 /* PredictionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F531D91B6D591C00A9E887 /* PredictionViewModel.swift */; };
 		49F531DD1B6E9E5B00A9E887 /* DatabaseLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F531DC1B6E9E5B00A9E887 /* DatabaseLoader.swift */; };
 		49F531DE1B6E9E5B00A9E887 /* DatabaseLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F531DC1B6E9E5B00A9E887 /* DatabaseLoader.swift */; };
-		59A4CE88EB7ED1203DE138D4 /* Pods_SubwayMapTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A868E11E4A809C123EF6F4E9 /* Pods_SubwayMapTests.framework */; };
-		DF4B99A0190F44320C591BFA /* Pods_SubwayMap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1AD6E17ADA74144E92FD327 /* Pods_SubwayMap.framework */; };
+		60038A17F3E80650135D1BFD /* Pods_SubwayMap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8D37697FA76898D291D5BE0 /* Pods_SubwayMap.framework */; };
 		8355AC6C1B94A1B2002F0527 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8355AC6B1B94A1B2002F0527 /* FavoritesManager.swift */; };
 		8355AC6D1B94A1B2002F0527 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8355AC6B1B94A1B2002F0527 /* FavoritesManager.swift */; };
 		8355AC6F1B94A1C8002F0527 /* FavoritesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8355AC6E1B94A1C8002F0527 /* FavoritesManagerTests.swift */; };
+		C7F879CAABEDAEDB9491B121 /* Pods_SubwayMapTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 167DC9B12C5DC62533041B63 /* Pods_SubwayMapTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,10 +65,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		04DFCE702E06D194260037D2 /* Pods-SubwayMapTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMapTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests.debug.xcconfig"; sourceTree = "<group>"; };
-		2FEF38240487DE01F31F28D9 /* Pods_SubwayMapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		36DF562699FA113857BB7C43 /* Pods-SubwayMapTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMapTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests.release.xcconfig"; sourceTree = "<group>"; };
-		387A1DFA8D56DD71BF31F3C5 /* Pods_SubwayMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		167DC9B12C5DC62533041B63 /* Pods_SubwayMapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		439699BB85364EF2B617A096 /* Pods-SubwayMap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMap.release.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap.release.xcconfig"; sourceTree = "<group>"; };
 		4918311C1B672B6900EB8328 /* SubwayMap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SubwayMap.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		491831201B672B6900EB8328 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		491831211B672B6900EB8328 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -84,6 +86,8 @@
 		499EC9931BEA9462004A1553 /* LineChoiceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineChoiceView.swift; sourceTree = "<group>"; };
 		499EC9951BEA947C004A1553 /* LineChoiceView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LineChoiceView.xib; sourceTree = "<group>"; };
 		499EC9991BEABE7F004A1553 /* LineViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineViewModel.swift; sourceTree = "<group>"; };
+		49B5C8B91BE1AB8D00636717 /* FavoritesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesViewController.swift; sourceTree = "<group>"; };
+		49B5C8BA1BE1AB8D00636717 /* FavoritesViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FavoritesViewController.xib; sourceTree = "<group>"; };
 		49B5C8C51BE247C200636717 /* StationTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StationTableViewCell.swift; sourceTree = "<group>"; };
 		49B5C8C61BE247C200636717 /* StationTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StationTableViewCell.xib; sourceTree = "<group>"; };
 		49D5359C1B69C44C0087D368 /* MapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
@@ -91,13 +95,12 @@
 		49F531D61B6D4DD500A9E887 /* NYCRouteColorManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYCRouteColorManager.swift; sourceTree = "<group>"; };
 		49F531D91B6D591C00A9E887 /* PredictionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PredictionViewModel.swift; sourceTree = "<group>"; };
 		49F531DC1B6E9E5B00A9E887 /* DatabaseLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseLoader.swift; sourceTree = "<group>"; };
-<<<<<<< fde24404982395d1d7495df53085632bda315c42
-		4BB8308FBA1DFDFC7E5081B5 /* Pods-SubwayMap.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMap.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap.debug.xcconfig"; sourceTree = "<group>"; };
-		A13F3E14FA8E73B74979798F /* Pods-SubwayMap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMap.release.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap.release.xcconfig"; sourceTree = "<group>"; };
-		A868E11E4A809C123EF6F4E9 /* Pods_SubwayMapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		ABF52ACD35DF59C8247AC37A /* Pods-SubwayMapTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMapTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests.release.xcconfig"; sourceTree = "<group>"; };
-		F1AD6E17ADA74144E92FD327 /* Pods_SubwayMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };		8355AC6B1B94A1B2002F0527 /* FavoritesManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesManager.swift; sourceTree = "<group>"; };
+		8355AC6B1B94A1B2002F0527 /* FavoritesManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesManager.swift; sourceTree = "<group>"; };
 		8355AC6E1B94A1C8002F0527 /* FavoritesManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoritesManagerTests.swift; sourceTree = "<group>"; };
+		8A6452C54932A2EA20A77FEA /* Pods-SubwayMapTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMapTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests.release.xcconfig"; sourceTree = "<group>"; };
+		CF275424296109495D025BF4 /* Pods-SubwayMap.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMap.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap.debug.xcconfig"; sourceTree = "<group>"; };
+		F8D37697FA76898D291D5BE0 /* Pods_SubwayMap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SubwayMap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FE8CAFD7E5DB86D08BA60F06 /* Pods-SubwayMapTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubwayMapTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,7 +110,7 @@
 			files = (
 				493DC1911B9D0CD700515F4B /* libz.dylib in Frameworks */,
 				491831481B67321A00EB8328 /* libsqlite3.dylib in Frameworks */,
-				DF4B99A0190F44320C591BFA /* Pods_SubwayMap.framework in Frameworks */,
+				60038A17F3E80650135D1BFD /* Pods_SubwayMap.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -116,7 +119,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4918319C1B67491D00EB8328 /* libsqlite3.dylib in Frameworks */,
-				59A4CE88EB7ED1203DE138D4 /* Pods_SubwayMapTests.framework in Frameworks */,
+				C7F879CAABEDAEDB9491B121 /* Pods_SubwayMapTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -130,8 +133,8 @@
 				493DC18C1B9CE01B00515F4B /* libz.1.2.5.dylib */,
 				493DC1871B9CD10500515F4B /* libz.dylib */,
 				491831471B67321A00EB8328 /* libsqlite3.dylib */,
-				F1AD6E17ADA74144E92FD327 /* Pods_SubwayMap.framework */,
-				A868E11E4A809C123EF6F4E9 /* Pods_SubwayMapTests.framework */,
+				F8D37697FA76898D291D5BE0 /* Pods_SubwayMap.framework */,
+				167DC9B12C5DC62533041B63 /* Pods_SubwayMapTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -143,7 +146,7 @@
 				491831341B672B6900EB8328 /* SubwayMapTests */,
 				4918311D1B672B6900EB8328 /* Products */,
 				0561CA4C571669088714DF0D /* Frameworks */,
-				B24D504376FC1B2AB4C55115 /* Pods */,
+				59421B6B890CCA459AC496DC /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -214,6 +217,8 @@
 				491831421B672E8C00EB8328 /* StationViewController.xib */,
 				49D5359C1B69C44C0087D368 /* MapViewController.swift */,
 				49D5359D1B69C44C0087D368 /* MapViewController.xib */,
+				49B5C8B91BE1AB8D00636717 /* FavoritesViewController.swift */,
+				49B5C8BA1BE1AB8D00636717 /* FavoritesViewController.xib */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -240,13 +245,13 @@
 			name = Models;
 			sourceTree = "<group>";
 		};
-		B24D504376FC1B2AB4C55115 /* Pods */ = {
+		59421B6B890CCA459AC496DC /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				4BB8308FBA1DFDFC7E5081B5 /* Pods-SubwayMap.debug.xcconfig */,
-				A13F3E14FA8E73B74979798F /* Pods-SubwayMap.release.xcconfig */,
-				04DFCE702E06D194260037D2 /* Pods-SubwayMapTests.debug.xcconfig */,
-				ABF52ACD35DF59C8247AC37A /* Pods-SubwayMapTests.release.xcconfig */,
+				CF275424296109495D025BF4 /* Pods-SubwayMap.debug.xcconfig */,
+				439699BB85364EF2B617A096 /* Pods-SubwayMap.release.xcconfig */,
+				FE8CAFD7E5DB86D08BA60F06 /* Pods-SubwayMapTests.debug.xcconfig */,
+				8A6452C54932A2EA20A77FEA /* Pods-SubwayMapTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -258,13 +263,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4918313B1B672B6900EB8328 /* Build configuration list for PBXNativeTarget "SubwayMap" */;
 			buildPhases = (
-				911D860FDB7B7B6595137907 /* Check Pods Manifest.lock */,
+				BAA175B62B0F0268B373EF6C /* 📦 Check Pods Manifest.lock */,
 				491831181B672B6900EB8328 /* Sources */,
 				491831191B672B6900EB8328 /* Frameworks */,
 				4918311A1B672B6900EB8328 /* Resources */,
 				496241B51B6ECBC6007053DC /* ShellScript */,
-				9117EB3C5C4CC21161C421E2 /* Embed Pods Frameworks */,
-				3AE9F43528A6E2372F84066C /* Copy Pods Resources */,
+				28ADBD6BF4473153AA5AF845 /* 📦 Copy Pods Resources */,
+				4293D72BAEA405F00434F8DA /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -279,12 +284,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4918313E1B672B6900EB8328 /* Build configuration list for PBXNativeTarget "SubwayMapTests" */;
 			buildPhases = (
-				14899B7A9205975B46573639 /* Check Pods Manifest.lock */,
+				E137DD5EB100A724A1E2DEC5 /* 📦 Check Pods Manifest.lock */,
 				4918312D1B672B6900EB8328 /* Sources */,
 				4918312E1B672B6900EB8328 /* Frameworks */,
 				4918312F1B672B6900EB8328 /* Resources */,
-				A3E37BF8DFA0FD9BF7A7E8CA /* Embed Pods Frameworks */,
-				1E940E83F890DBB17ACA7039 /* Copy Pods Resources */,
+				01440720A2CBBD7056237279 /* 📦 Embed Pods Frameworks */,
+				491FC0553F2F248C0DCB9836 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -304,7 +309,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0640;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = Thryv;
 				TargetAttributes = {
 					4918311B1B672B6900EB8328 = {
@@ -345,6 +350,7 @@
 				491831291B672B6900EB8328 /* Images.xcassets in Resources */,
 				491831451B672E8C00EB8328 /* StationViewController.xib in Resources */,
 				49B5C8C91BE247C200636717 /* StationTableViewCell.xib in Resources */,
+				49B5C8BD1BE1AB8D00636717 /* FavoritesViewController.xib in Resources */,
 				49D535A01B69C44C0087D368 /* MapViewController.xib in Resources */,
 				499EC9961BEA947C004A1553 /* LineChoiceView.xib in Resources */,
 			);
@@ -359,6 +365,7 @@
 				49B5C8CA1BE247C200636717 /* StationTableViewCell.xib in Resources */,
 				499EC9981BEAA701004A1553 /* LineChoiceView.xib in Resources */,
 				491831D51B69A61700EB8328 /* PredictionTableViewCell.xib in Resources */,
+				49B5C8BE1BE1AB8D00636717 /* FavoritesViewController.xib in Resources */,
 				49D535A11B69C44C0087D368 /* MapViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -366,49 +373,64 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		14899B7A9205975B46573639 /* Check Pods Manifest.lock */ = {
+		01440720A2CBBD7056237279 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1E940E83F890DBB17ACA7039 /* Copy Pods Resources */ = {
+		28ADBD6BF4473153AA5AF845 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		3AE9F43528A6E2372F84066C /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4293D72BAEA405F00434F8DA /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		491FC0553F2F248C0DCB9836 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		496241B51B6ECBC6007053DC /* ShellScript */ = {
@@ -422,31 +444,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Fabric/Fabric.framework/run\" b1bc39c835159dcffd9f2950a40007e570069713 dde132f14bcd45d54cbbb551f59876744bc3ab28f3e393f236602a2354a4994a";
+			shellScript = "\"${PODS_ROOT}/Fabric/run\" b1bc39c835159dcffd9f2950a40007e570069713 dde132f14bcd45d54cbbb551f59876744bc3ab28f3e393f236602a2354a4994a";
 		};
-		9117EB3C5C4CC21161C421E2 /* Embed Pods Frameworks */ = {
+		BAA175B62B0F0268B373EF6C /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SubwayMap/Pods-SubwayMap-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		911D860FDB7B7B6595137907 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -454,19 +461,19 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		A3E37BF8DFA0FD9BF7A7E8CA /* Embed Pods Frameworks */ = {
+		E137DD5EB100A724A1E2DEC5 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SubwayMapTests/Pods-SubwayMapTests-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -477,6 +484,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				491831221B672B6900EB8328 /* AppDelegate.swift in Sources */,
+				49B5C8BB1BE1AB8D00636717 /* FavoritesViewController.swift in Sources */,
 				49F531DA1B6D591C00A9E887 /* PredictionViewModel.swift in Sources */,
 				49B5C8C71BE247C200636717 /* StationTableViewCell.swift in Sources */,
 				49F531DD1B6E9E5B00A9E887 /* DatabaseLoader.swift in Sources */,
@@ -505,6 +513,7 @@
 				49D5359F1B69C44C0087D368 /* MapViewController.swift in Sources */,
 				499EC99B1BEABE7F004A1553 /* LineViewModel.swift in Sources */,
 				49F531D81B6D4DD500A9E887 /* NYCRouteColorManager.swift in Sources */,
+				49B5C8BC1BE1AB8D00636717 /* FavoritesViewController.swift in Sources */,
 				8355AC6D1B94A1B2002F0527 /* FavoritesManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -542,6 +551,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -605,27 +615,39 @@
 		};
 		4918313C1B672B6900EB8328 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4BB8308FBA1DFDFC7E5081B5 /* Pods-SubwayMap.debug.xcconfig */;
+			baseConfigurationReference = CF275424296109495D025BF4 /* Pods-SubwayMap.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$CONFIGURATION_BUILD_DIR/GTFSStations\"",
+					"\"$CONFIGURATION_BUILD_DIR/NagController\"",
+					"\"$CONFIGURATION_BUILD_DIR/SBTextInputView\"",
+					"\"$CONFIGURATION_BUILD_DIR/SQLite.swift\"",
+					"\"$CONFIGURATION_BUILD_DIR/ZipArchive\"",
+					"\"${PODS_ROOT}/Crashlytics/iOS\"",
+					"\"${PODS_ROOT}/Fabric/iOS\"",
+				);
 				INFOPLIST_FILE = SubwayMap/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.thryv.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_INCLUDE_PATHS = "/Users/ell/development/ios/apps/subway-ios/SubwayMap/";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		4918313D1B672B6900EB8328 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A13F3E14FA8E73B74979798F /* Pods-SubwayMap.release.xcconfig */;
+			baseConfigurationReference = 439699BB85364EF2B617A096 /* Pods-SubwayMap.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -635,16 +657,18 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.thryv.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "c79244ae-12bb-4fd2-bcbb-ce791883da09";
 				SWIFT_INCLUDE_PATHS = "/Users/ell/development/ios/apps/subway-ios/SubwayMap/";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "/Users/HeidiHansen1/Code/thryv/subway-ios/SubwayMap/SubwayMap-Bridging-Header.h";
 			};
 			name = Release;
 		};
 		4918313F1B672B6900EB8328 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04DFCE702E06D194260037D2 /* Pods-SubwayMapTests.debug.xcconfig */;
+			baseConfigurationReference = FE8CAFD7E5DB86D08BA60F06 /* Pods-SubwayMapTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
@@ -658,6 +682,7 @@
 				);
 				INFOPLIST_FILE = SubwayMapTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.thryv.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
@@ -668,7 +693,7 @@
 		};
 		491831401B672B6900EB8328 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = ABF52ACD35DF59C8247AC37A /* Pods-SubwayMapTests.release.xcconfig */;
+			baseConfigurationReference = 8A6452C54932A2EA20A77FEA /* Pods-SubwayMapTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
@@ -678,6 +703,7 @@
 				);
 				INFOPLIST_FILE = SubwayMapTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.thryv.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";

--- a/SubwayMap/AppDelegate.swift
+++ b/SubwayMap/AppDelegate.swift
@@ -56,7 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, NagControllerDelegate {
 
     func applicationDidBecomeActive(application: UIApplication) {
         var appOpens = NSUserDefaults.standardUserDefaults().integerForKey("numberOfAppOpens")
-        appOpens++
+        appOpens += 1
         NSUserDefaults.standardUserDefaults().setInteger(appOpens, forKey: "numberOfAppOpens")
         
         if appOpens % 3 == 0 {

--- a/SubwayMap/DatabaseLoader.swift
+++ b/SubwayMap/DatabaseLoader.swift
@@ -44,7 +44,7 @@ class DatabaseLoader: NSObject {
             let fileUrl = NSURL(fileURLWithPath: destinationPath)
             do {
                 try fileUrl.setResourceValue(NSNumber(bool: true), forKey: NSURLIsExcludedFromBackupKey)
-            } catch var error1 as NSError {
+            } catch let error1 as NSError {
                 error = error1
             }
         }

--- a/SubwayMap/FavoritesManager.swift
+++ b/SubwayMap/FavoritesManager.swift
@@ -10,8 +10,9 @@ import Foundation
 import GTFSStations
 
 class FavoritesManager: NSObject {
-    var favoriteIds: Array<String>
+    var favoriteIds: [String]!
     var stationManager: StationManager
+    var stations: [Station]?
     
     private let defaultsKey = "favorite_stations"
     
@@ -19,7 +20,7 @@ class FavoritesManager: NSObject {
         self.stationManager = stationManager
         self.favoriteIds = []
 
-        if let names = NSUserDefaults.standardUserDefaults().stringArrayForKey(defaultsKey) as? Array<String> {
+        if let names = NSUserDefaults.standardUserDefaults().stringArrayForKey(defaultsKey) as [String]! {
             self.favoriteIds = names
         }
         
@@ -27,20 +28,20 @@ class FavoritesManager: NSObject {
     }
     
     // add stations to favorites list
-    func addFavorites(stations: Array<Station>) {
+    func addFavorites(stations: [Station]) {
         for station in stations {
-            if !contains(favoriteIds, station.objectId) {
-                favoriteIds.append(station.objectId)
+            if !favoriteIds.contains(station.name) {
+                favoriteIds.append(station.name)
             }
         }
         sync()
     }
     
     // remove stations from favorites list
-    func removeFavorites(stations: Array<Station>) {
+    func removeFavorites(stations: [Station]) {
         for station in stations {
-            if contains(favoriteIds, station.objectId) {
-                favoriteIds = favoriteIds.filter( { $0 != station.objectId } )
+            if favoriteIds.contains(station.name) {
+                favoriteIds = favoriteIds.filter( { $0 != station.name } )
             }
         }
         sync()
@@ -53,12 +54,29 @@ class FavoritesManager: NSObject {
     }
     
     // find favorites by substring
-    func findFavorites(name: String?) -> Array<Station>? {
+    func findFavorites(name: String?) -> [Station]? {
         if name != nil {
-            return stationManager.stationsForSearchString(name)!.filter({contains(self.favoriteIds, $0.objectId)})
+            return stationManager.stationsForSearchString(name)!.filter({self.favoriteIds.contains($0.name)})
         } else {
-            return stationManager.allStations.filter({contains(self.favoriteIds, $0.objectId)})
+            return stationManager.allStations.filter({self.favoriteIds.contains($0.name)})
         }
+    }
+    
+    // get all favorites
+    func favoriteStations() -> [Station]? {
+        return findFavorites(nil)
+    }
+    
+    //check if current station exists in favorites
+    func isFavorite(name: String?) -> Bool {
+        let stations: [Station]? = findFavorites(name)
+        var isInArray: Bool = false
+        for station in stations! {
+            if station.name == name {
+                isInArray = true
+            }
+        }
+        return isInArray
     }
 
     // flush out user defaults

--- a/SubwayMap/FavoritesManager.swift
+++ b/SubwayMap/FavoritesManager.swift
@@ -1,0 +1,70 @@
+//
+//  FavoritesManager.swift
+//  SubwayMap
+//
+//  Created by Cliff Spencer on 8/30/15.
+//  Copyright (c) 2015 Thryv. All rights reserved.
+//
+
+import Foundation
+import GTFSStations
+
+class FavoritesManager: NSObject {
+    var favoriteIds: Array<String>
+    var stationManager: StationManager
+    
+    private let defaultsKey = "favorite_stations"
+    
+    init(stationManager: StationManager) {
+        self.stationManager = stationManager
+        self.favoriteIds = []
+
+        if let names = NSUserDefaults.standardUserDefaults().stringArrayForKey(defaultsKey) as? Array<String> {
+            self.favoriteIds = names
+        }
+        
+        super.init()
+    }
+    
+    // add stations to favorites list
+    func addFavorites(stations: Array<Station>) {
+        for station in stations {
+            if !contains(favoriteIds, station.objectId) {
+                favoriteIds.append(station.objectId)
+            }
+        }
+        sync()
+    }
+    
+    // remove stations from favorites list
+    func removeFavorites(stations: Array<Station>) {
+        for station in stations {
+            if contains(favoriteIds, station.objectId) {
+                favoriteIds = favoriteIds.filter( { $0 != station.objectId } )
+            }
+        }
+        sync()
+    }
+    
+    // clear all favorites
+    func clear() {
+        favoriteIds.removeAll(keepCapacity: true)
+        sync()
+    }
+    
+    // find favorites by substring
+    func findFavorites(name: String?) -> Array<Station>? {
+        if name != nil {
+            return stationManager.stationsForSearchString(name)!.filter({contains(self.favoriteIds, $0.objectId)})
+        } else {
+            return stationManager.allStations.filter({contains(self.favoriteIds, $0.objectId)})
+        }
+    }
+
+    // flush out user defaults
+    private func sync() {
+        let defaults = NSUserDefaults.standardUserDefaults()
+        defaults.setObject(favoriteIds, forKey: defaultsKey)
+        defaults.synchronize()
+    }
+}

--- a/SubwayMap/FavoritesViewController.swift
+++ b/SubwayMap/FavoritesViewController.swift
@@ -1,0 +1,79 @@
+//
+//  FavoritesViewController.swift
+//  SubwayMap
+//
+//  Created by Elliot Schrock on 10/28/15.
+//  Copyright © 2015 Thryv. All rights reserved.
+//
+
+import UIKit
+import GTFSStations
+import CoreGraphics
+
+class FavoritesViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    @IBOutlet weak var tableView: UITableView!
+    var stationManager: StationManager!
+    var favManager: FavoritesManager!
+    var stations: [Station]?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.edgesForExtendedLayout = UIRectEdge.None
+        
+        tableView.registerNib(UINib(nibName: "StationTableViewCell", bundle: nil), forCellReuseIdentifier: "cell")
+        tableView.dataSource = self
+        tableView.delegate = self
+        
+        title = "FAVORITES"
+        favManager = FavoritesManager(stationManager: stationManager)
+        self.stations = favManager.favoriteStations()
+        tableView.reloadData()
+        tableView.tableFooterView = UIView()
+    }
+    
+    func configureCellLines(cell: StationTableViewCell, station: Station){
+        cell.stationNameLabel?.text = station.name
+        for imageView in cell.orderedLineImageViews! {
+            imageView.image = nil
+        }
+    }
+    
+    //MARK: table data source
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.stations!.count
+    }
+    
+    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+        return 80
+    }
+    
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier("cell")! as! StationTableViewCell
+        let station = self.stations![indexPath.row]
+        configureCellLines(cell, station: station)
+        if let stationArray = stations {
+            let station = stationArray[indexPath.row]
+            configureCellLines(cell, station: station)
+        }
+        return cell
+    }
+    
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        let station = self.stations![indexPath.row]
+        let barButton = UIBarButtonItem()
+        barButton.title = ""
+        navigationItem.backBarButtonItem = barButton
+        
+        let stationVC = StationViewController(nibName: "StationViewController", bundle: nil)
+        stationVC.stationManager = stationManager
+        stationVC.station = station
+        navigationController?.pushViewController(stationVC, animated: true)
+    }
+}
+
+

--- a/SubwayMap/FavoritesViewController.xib
+++ b/SubwayMap/FavoritesViewController.xib
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FavoritesViewController" customModule="SubwayMap" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="zl9-ta-d6X" id="EoQ-jR-DDe"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="zl9-ta-d6X">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="zl9-ta-d6X" secondAttribute="trailing" id="7EU-Wr-DzH"/>
+                <constraint firstAttribute="bottom" secondItem="zl9-ta-d6X" secondAttribute="bottom" id="C9j-hT-UvQ"/>
+                <constraint firstItem="zl9-ta-d6X" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="aXQ-k7-mfu"/>
+                <constraint firstItem="zl9-ta-d6X" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="xKm-Fk-Nxd"/>
+            </constraints>
+        </view>
+    </objects>
+</document>

--- a/SubwayMap/Info.plist
+++ b/SubwayMap/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.thryv.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SubwayMap/MapViewController.swift
+++ b/SubwayMap/MapViewController.swift
@@ -16,7 +16,7 @@ class MapViewController: UIViewController, UIScrollViewDelegate, UISearchBarDele
     @IBOutlet weak var subwayImageView: UIImageView!
     @IBOutlet weak var loadingImageView: UIImageView!
     var stationManager: StationManager!
-    var stations: Array<Station>?
+    var stations: [Station]?
     var loading = false
 
     override func viewDidLoad() {
@@ -26,20 +26,43 @@ class MapViewController: UIViewController, UIScrollViewDelegate, UISearchBarDele
         
         title = "SUBWAY:NYC"
         navigationController?.navigationBar.barStyle = UIBarStyle.Black
-        
+        setupFavoritesButton()
         searchBar.delegate = self
         
         tableView.registerNib(UINib(nibName: "StationTableViewCell", bundle: nil), forCellReuseIdentifier: "cell")
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.tableFooterView = UIView() //removes cell separators between empty cells
         
         if !DatabaseLoader.isDatabaseReady {
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "databaseLoaded", name: DatabaseLoader.NYCDatabaseLoadedNotification, object: nil)
+            NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(MapViewController.databaseLoaded), name: DatabaseLoader.NYCDatabaseLoadedNotification, object: nil)
             searchBar.alpha = 0
             startLoading()
         }else{
             databaseLoaded()
         }
+    }
+    
+    func setupFavoritesButton() {
+        let favButton = UIButton()
+        favButton.frame = CGRectMake(0, 0, 30, 30)
+        favButton.setImage(UIImage(named: "Hover")?.imageWithRenderingMode(.AlwaysOriginal), forState: .Normal)
+        favButton.setImage(UIImage(named: "Pressed")?.imageWithRenderingMode(.AlwaysOriginal), forState: UIControlState.Selected.union(.Highlighted))
+        favButton.addTarget(self, action: #selector(MapViewController.openFavorites), forControlEvents: .TouchUpInside)
+        
+        let favBarButton = UIBarButtonItem()
+        favBarButton.customView = favButton
+        self.navigationItem.rightBarButtonItem = favBarButton
+    }
+    
+    func openFavorites() {
+        let barButton = UIBarButtonItem()
+        barButton.title = ""
+        navigationItem.backBarButtonItem = barButton
+        
+        let favoritesVC = FavoritesViewController(nibName: "FavoritesViewController", bundle: nil)
+        favoritesVC.stationManager = stationManager
+        navigationController?.pushViewController(favoritesVC, animated: true)
     }
     
     deinit {
@@ -169,7 +192,7 @@ class MapViewController: UIViewController, UIScrollViewDelegate, UISearchBarDele
     }
     
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return (stations ?? Array<Station>()).count
+        return (stations ?? [Station]()).count
     }
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {

--- a/SubwayMap/PredictionViewModel.swift
+++ b/SubwayMap/PredictionViewModel.swift
@@ -21,7 +21,7 @@ class PredictionViewModel: NSObject {
         self.direction = direction
     }
     
-    func setupWithPredictions(predictions: Array<Prediction>!){
+    func setupWithPredictions(predictions: [Prediction]!){
         var relevantPredictions = predictions.filter({(prediction) -> Bool in
             return prediction.direction == self.direction && prediction.route!.objectId == self.routeId
         })

--- a/SubwayMap/StationViewController.swift
+++ b/SubwayMap/StationViewController.swift
@@ -24,6 +24,7 @@ class StationViewController: UIViewController, UITableViewDataSource, UITableVie
     var routes: [Route] = [Route]()
     var lineModels: [LineViewModel] = [LineViewModel]()
     var lineViews = [LineChoiceView]()
+    var favManager: FavoritesManager!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -37,11 +38,44 @@ class StationViewController: UIViewController, UITableViewDataSource, UITableVie
         refresh()
         
         title = station.name
+        favManager = FavoritesManager(stationManager: stationManager)
+        setupFavoritesButton()
     }
     
     override func viewDidAppear(animated: Bool) {
         refresh()
         tableView.reloadData()
+    }
+    
+    func setupFavoritesButton() {
+        let favButton = UIButton()
+        favButton.frame = CGRectMake(0, 0, 30, 30)
+        
+        if favManager.isFavorite(station.name){
+            favButton.setImage(UIImage(named: "Star_pressed")?.imageWithRenderingMode(.AlwaysOriginal), forState: .Normal)
+        } else {
+            favButton.setImage(UIImage(named: "Star")?.imageWithRenderingMode(.AlwaysOriginal), forState: .Normal)
+        }
+        
+        favButton.addTarget(self, action: #selector(StationViewController.toggleFavoriteStation), forControlEvents: .TouchUpInside)
+        
+        let favBarButton = UIBarButtonItem()
+        favBarButton.customView = favButton
+        self.navigationItem.rightBarButtonItem = favBarButton
+    }
+
+    func toggleFavoriteStation() {
+        if favManager.isFavorite(station.name) {
+            favManager.removeFavorites([self.station])
+        } else {
+            favManager.addFavorites([station])
+        }
+        setupFavoritesButton()
+    }
+
+    @IBAction func favoriteThisStation() {
+        favManager.addFavorites([station])
+        setupFavoritesButton()
     }
     
     func refresh() {
@@ -123,7 +157,7 @@ class StationViewController: UIViewController, UITableViewDataSource, UITableVie
             lineView.updateConstraints()
             lineView.setNeedsLayout()
             lineView.layoutIfNeeded()
-            count++
+            count += 1
         }
     }
     

--- a/SubwayMap/StationViewController.xib
+++ b/SubwayMap/StationViewController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="StationViewController" customModule="SubwayMap" customModuleProvider="target">
@@ -39,16 +39,27 @@
                     <rect key="frame" x="258" y="8" width="75" height="30"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                 </view>
+                <button hidden="YES" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vaf-PN-w7C">
+                    <rect key="frame" x="509" y="501" width="71" height="77"/>
+                    <state key="normal" image="Hover"/>
+                    <state key="selected" image="Pressed"/>
+                    <state key="highlighted" image="Pressed"/>
+                    <connections>
+                        <action selector="favoriteThisStation" destination="-1" eventType="touchUpInside" id="Y8D-iy-uwy"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="0.22745098039215686" green="0.22745098039215686" blue="0.22745098039215686" alpha="1" colorSpace="calibratedRGB"/>
             <constraints>
                 <constraint firstItem="3xQ-WY-BR1" firstAttribute="top" secondItem="1pV-ea-GYC" secondAttribute="bottom" constant="8" id="11V-0A-hIL"/>
                 <constraint firstItem="p4Q-LI-GHL" firstAttribute="top" secondItem="4sx-0l-vVR" secondAttribute="top" id="5Ac-wQ-zI6"/>
                 <constraint firstItem="3xQ-WY-BR1" firstAttribute="top" secondItem="p4Q-LI-GHL" secondAttribute="bottom" constant="8" id="FiM-rY-cTd"/>
+                <constraint firstAttribute="trailing" secondItem="Vaf-PN-w7C" secondAttribute="trailing" constant="21" id="M8I-MV-KhT"/>
                 <constraint firstAttribute="trailing" secondItem="3xQ-WY-BR1" secondAttribute="trailing" id="MYf-IT-EPA"/>
                 <constraint firstItem="3xQ-WY-BR1" firstAttribute="top" secondItem="JP6-Uf-w41" secondAttribute="bottom" constant="8" id="Qis-K2-Hbu"/>
                 <constraint firstItem="1pV-ea-GYC" firstAttribute="top" secondItem="JP6-Uf-w41" secondAttribute="top" id="R4N-lo-ncD"/>
                 <constraint firstAttribute="bottom" secondItem="3xQ-WY-BR1" secondAttribute="bottom" id="cUe-wM-GjR"/>
+                <constraint firstAttribute="bottom" secondItem="Vaf-PN-w7C" secondAttribute="bottom" constant="21" id="cqY-lk-p7d"/>
                 <constraint firstItem="1pV-ea-GYC" firstAttribute="leading" secondItem="JP6-Uf-w41" secondAttribute="trailing" constant="8" id="iW4-MC-Kec"/>
                 <constraint firstItem="JP6-Uf-w41" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="8" id="p06-Xr-IUW"/>
                 <constraint firstItem="3xQ-WY-BR1" firstAttribute="top" secondItem="4sx-0l-vVR" secondAttribute="bottom" constant="8" id="pxR-0T-FaE"/>
@@ -61,4 +72,8 @@
             <point key="canvasLocation" x="392" y="439"/>
         </view>
     </objects>
+    <resources>
+        <image name="Hover" width="71" height="77"/>
+        <image name="Pressed" width="71" height="77"/>
+    </resources>
 </document>

--- a/SubwayMapTests/FavoritesManagerTests.swift
+++ b/SubwayMapTests/FavoritesManagerTests.swift
@@ -1,0 +1,116 @@
+//
+//  FavoritesManagerTest.swift
+//  SubwayMap
+//
+//  Created by Cliff Spencer on 8/30/15.
+//  Copyright (c) 2015 Thryv. All rights reserved.
+//
+
+import Quick
+import Nimble
+import GTFSStations
+
+
+class FavoritesSpec: QuickSpec {
+    override func spec() {
+        describe("Favorites", { () -> Void in
+            let stationManager: StationManager! = StationManager(filename: "gtfs.db")
+            let favoritesManager: FavoritesManager! = FavoritesManager(stationManager: stationManager)
+            
+            it("can clear all favorites") {
+                let stationName = "Astor Pl"
+                let stations: Array<Station>? = stationManager.stationsForSearchString(stationName)
+                expect(stations).toNot(beNil())
+                expect(stations!.count == 1).to(beTruthy())
+                
+                favoritesManager.addFavorites(stations!)
+                let favorites: Array<Station>? = favoritesManager.findFavorites(nil)
+                expect(favorites!.count).to(beTruthy())
+                
+                favoritesManager.clear()
+                let emptyFavorites = favoritesManager.findFavorites(nil)
+                expect(stations).toNot(beNil())
+                expect(emptyFavorites!.isEmpty).to(beTruthy())
+            }
+            
+            it("can add a favorite") {
+                let allStations = stationManager.allStations
+                let station = allStations.first
+                favoritesManager.addFavorites([station!])
+                
+                let favorites: Array<Station>? = favoritesManager.findFavorites(nil)
+                expect(favorites).toNot(beNil())
+                expect(favorites!.count).to(beTruthy())
+                expect(favorites).to(contain(station))
+            }
+            
+            it("can remove a favorite") {
+                let stations = Array(stationManager.allStations[0...2])
+                expect(stations.count == 3).to(beTrue())
+                favoritesManager.addFavorites(stations)
+                
+                favoritesManager.removeFavorites([stations[1]])
+                var favorites: Array<Station>? = favoritesManager.findFavorites(nil)
+                expect(favorites).toNot(contain(stations[1]))
+            }
+            
+            it ("can find a favorite") {
+                favoritesManager.clear()
+                let stationName = "Astor Pl"
+                let stations: Array<Station>? = stationManager.stationsForSearchString(stationName)
+                expect(stations).toNot(beNil())
+                expect(stations!.count == 1).to(beTruthy())
+                
+                let favorites: Array<Station>? = favoritesManager.findFavorites(stationName)
+                
+                expect(stations).toNot(beNil())
+                expect(stations!.count == 1).to(beTrue())
+                expect(stations![0].name == stationName).to(beTruthy())
+            }
+            
+            it ("can find multiple favorites") {
+                favoritesManager.clear()
+                let stationName = "Astor"
+                let stations: Array<Station>? = stationManager.stationsForSearchString(stationName)
+                expect(stations).toNot(beNil())
+                expect(stations!.count == 3).to(beTruthy())
+                
+                favoritesManager.addFavorites(stations!)
+
+                let favorites: Array<Station>? = favoritesManager.findFavorites(stationName)
+                expect(stations).toNot(beNil())
+                expect(stations!.count == 3).to(beTrue())
+                
+                for stationName in ["Astor Pl", "Astoria Blvd", "Astoria - Ditmars Blvd"] {
+                    let station = favorites!.filter( { $0.name == stationName } )
+                    expect(station).toNot(beNil())
+                    expect(station.count == 1).to(beTrue())
+                    println("station: \(stationName)")
+                    expect(station[0].name == stationName).to(beTruthy())
+
+                }
+            }
+            
+            it ("can save and restore favorites") {
+                favoritesManager.clear()
+                let stationName = "Astor Pl"
+                let stations: Array<Station>? = stationManager.stationsForSearchString(stationName)
+                expect(stations).toNot(beNil())
+                expect(stations!.count == 1).to(beTruthy())
+                
+                favoritesManager.addFavorites(stations!)
+                
+                let newFavoritesManager: FavoritesManager! = FavoritesManager(stationManager: stationManager)
+                
+
+                let favorites: Array<Station>? = newFavoritesManager.findFavorites(stationName)
+                
+                expect(favorites).toNot(beNil())
+                expect(favorites!.count == 1).to(beTrue())
+                expect(favorites![0].name == stationName).to(beTruthy())
+            }
+            
+        })
+    }
+}
+

--- a/SubwayMapTests/Info.plist
+++ b/SubwayMapTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.thryv.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Please note that I bumped cocoapods version to 39 beta due to apparent issues in the preceding version. I'm using NSUserdefaults to store the favorites and at the moment the tests work using the actual defaults. Using a mock would be a better solution.  I elected to track station objectIds and resolve these from the StationManager so that changes in the db would be more transparent.
